### PR TITLE
Split PubSub topics and serving databases into production and staging

### DIFF
--- a/gcp/pubsub.tf
+++ b/gcp/pubsub.tf
@@ -1,3 +1,7 @@
-resource "google_pubsub_topic" "test" {
-  name = "test"
+resource "google_pubsub_topic" "ingestion-prod" {
+  name = "ingestion-prod"
+}
+
+resource "google_pubsub_topic" "ingestion-staging" {
+  name = "ingestion-staging"
 }

--- a/gcp/sql-database.tf
+++ b/gcp/sql-database.tf
@@ -7,12 +7,19 @@ resource "google_sql_database_instance" "analyzing" {
   }
 }
 
-//resource "google_sql_database" "serving" {
-//  name      = "servingDB"
-//  instance  = "${google_sql_database_instance.analyzing.name}"
-//  charset   = "latin1"
-//  collation = "latin1_swedish_ci"
-//}
+resource "google_sql_database" "serving-prod" {
+  name      = "serving-prod"
+  instance  = "${google_sql_database_instance.analyzing.name}"
+  charset   = "latin1"
+  collation = "latin1_swedish_ci"
+}
+
+resource "google_sql_database" "serving-staging" {
+  name      = "serving-staging"
+  instance  = "${google_sql_database_instance.analyzing.name}"
+  charset   = "latin1"
+  collation = "latin1_swedish_ci"
+}
 
 resource "google_sql_user" "users" {
   instance = "${google_sql_database_instance.analyzing.name}"

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -21,11 +21,6 @@ variable "default_node_pool_name" {
   description = "Name for default node pool of cluster."
 }
 
-variable "scalable_node_pool_name" {
-  type = "string"
-  description = "Name for secondary scalable node pool of cluster."
-}
-
 // GCP Outputs
 output "gcp_cluster_endpoint" {
   value = "${google_container_cluster.primary.endpoint}"

--- a/kubernetes/deployments/customer-service.yml
+++ b/kubernetes/deployments/customer-service.yml
@@ -21,3 +21,5 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
+        - name: PUBSUB_TOPICID
+          value: ingestion-prod

--- a/kubernetes/deployments/dashboard-service.yml
+++ b/kubernetes/deployments/dashboard-service.yml
@@ -21,6 +21,8 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
+        - name: SPRING_CLOUD_GCP_SQL_DATABASE_NAME
+          value: serving-prod
         - name: SPRING_DATASOURCE_USER
           valueFrom:
             secretKeyRef:

--- a/kubernetes/deployments/processing-pipeline.yml
+++ b/kubernetes/deployments/processing-pipeline.yml
@@ -21,3 +21,13 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
+        - name: PROJECT_ID
+          value: triangl-215714
+        - name: PUBSUB_TOPIC
+          value: ingestion-prod
+        - name: JDBC_URL
+          value: jdbc:mysql://google/serving-prod?cloudSqlInstance=triangl-215714:europe-west3:analyzing&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false
+        - name: DB_USER
+          value: root
+        - name: DB_PASSWORD
+          value: root

--- a/kubernetes/deployments/tracking-ingestion-service.yml
+++ b/kubernetes/deployments/tracking-ingestion-service.yml
@@ -21,3 +21,5 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
+        - name: PUBSUB_TOPIC
+          value: ingestion-prod


### PR DESCRIPTION
# What?
databases:
- created `serving-prod`
- created `serving-staging`
- removed `servingDB`

PubSub topics:
- created `ingestion-prod`
- created `ingestion-staging`
- removed `test`

K8s deployments:
- added database/PubSub access credentials as environment variables

# Why?
Now we can test our backend locally end-to-end. Especially it simplifies developing and testing our `processing-pipeline`.