### PR TITLE
Remove spring datasource credentials in dashboard-service deployment

### DIFF
--- a/kubernetes/deployments/dashboard-service.yml
+++ b/kubernetes/deployments/dashboard-service.yml
@@ -28,15 +28,5 @@ spec:
           value: /var/secrets/google/key.json
         - name: SPRING_CLOUD_GCP_SQL_DATABASE_NAME
           value: serving-prod
-        - name: SPRING_DATASOURCE_USER
-          valueFrom:
-            secretKeyRef:
-              name: dashboard-service-sql
-              key: username
-        - name: SPRING_DATASOURCE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: dashboard-service-sql
-              key: password
         - name: SENTRY_DSN
           value: https://4c03d389349a417e94c1446a4800352b@sentry.io/1318106


### PR DESCRIPTION
Now handled by the dashboard-service as default configuration.