### PR TITLE
Feat add readiness and liveness probe for spring services

### DIFF
--- a/kubernetes/deployments/customer-service.yml
+++ b/kubernetes/deployments/customer-service.yml
@@ -30,3 +30,19 @@ spec:
           value: ingestion-prod
         - name: SENTRY_DSN
           value: https://c72d446aead4482f9e0f39c18a034bda@sentry.io/1314460
+        livenessProbe:
+          httpGet:
+            path: /actuator/info
+            port: 8080
+          initialDelaySeconds: 120
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 120
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 2

--- a/kubernetes/deployments/dashboard-service.yml
+++ b/kubernetes/deployments/dashboard-service.yml
@@ -15,11 +15,6 @@ spec:
       containers:
       - name: dashboard-service
         image: eu.gcr.io/triangl-215714/dashboard-service:latest
-        resources:
-          limits:
-            cpu: "0.1"
-          requests:
-            cpu: "0.05"
         volumeMounts:
         - name: google-cloud-key
           mountPath: /var/secrets/google
@@ -30,3 +25,19 @@ spec:
           value: serving-prod
         - name: SENTRY_DSN
           value: https://4c03d389349a417e94c1446a4800352b@sentry.io/1318106
+        livenessProbe:
+          httpGet:
+            path: /actuator/info
+            port: 8080
+          initialDelaySeconds: 120
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 120
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 2

--- a/kubernetes/deployments/tracking-ingestion-service.yml
+++ b/kubernetes/deployments/tracking-ingestion-service.yml
@@ -30,3 +30,19 @@ spec:
           value: ingestion-prod
         - name: SENTRY_DSN
           value: https://e95b3a253e8040f9a32af069e5c6cdc8@sentry.io/1318093
+        livenessProbe:
+          httpGet:
+            path: /actuator/info
+            port: 8080
+          initialDelaySeconds: 120
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 120
+          timeoutSeconds: 2
+          periodSeconds: 5
+          failureThreshold: 2


### PR DESCRIPTION
# What?

- add readiness and liveness probe for spring services
- remove resource limits for `dashboard-service` to reduce startup time substantially

# Why?

- for seemless deployments kubernetes should not destroy the old pod before the new service is not able to handle requests (readiness probe)
- if the service looses the ability to handle requests at runtime but does not crash kubernetes should kill it (liveness probe)