### PR TITLE
Feat increase pod resource limits

### DIFF
--- a/kubernetes/deployments/customer-service.yml
+++ b/kubernetes/deployments/customer-service.yml
@@ -15,11 +15,6 @@ spec:
       containers:
       - name: customer-service
         image: eu.gcr.io/triangl-215714/customer-service:latest
-        resources:
-          limits:
-            cpu: "0.1"
-          requests:
-            cpu: "0.05"
         volumeMounts:
         - name: google-cloud-key
           mountPath: /var/secrets/google

--- a/kubernetes/deployments/dashboard-service.yml
+++ b/kubernetes/deployments/dashboard-service.yml
@@ -41,3 +41,6 @@ spec:
           timeoutSeconds: 2
           periodSeconds: 5
           failureThreshold: 2
+        resources:
+          requests:
+            cpu: 200m

--- a/kubernetes/deployments/dashboard.yml
+++ b/kubernetes/deployments/dashboard.yml
@@ -11,8 +11,3 @@ spec:
       containers:
       - name: dashboard
         image: eu.gcr.io/triangl-215714/dashboard:latest
-        resources:
-          limits:
-            cpu: "0.1"
-          requests:
-            cpu: "0.05"

--- a/kubernetes/deployments/processing-pipeline.yml
+++ b/kubernetes/deployments/processing-pipeline.yml
@@ -15,11 +15,6 @@ spec:
       containers:
       - name: processing-pipeline
         image: eu.gcr.io/triangl-215714/processing-pipeline:latest
-        resources:
-          limits:
-            cpu: "0.1"
-          requests:
-            cpu: "0.05"
         volumeMounts:
         - name: google-cloud-key
           mountPath: /var/secrets/google

--- a/kubernetes/deployments/tracking-ingestion-service.yml
+++ b/kubernetes/deployments/tracking-ingestion-service.yml
@@ -15,11 +15,6 @@ spec:
       containers:
       - name: tracking-ingestion-service
         image: eu.gcr.io/triangl-215714/tracking-ingestion-service:latest
-        resources:
-          limits:
-            cpu: "0.1"
-          requests:
-            cpu: "0.05"
         volumeMounts:
         - name: google-cloud-key
           mountPath: /var/secrets/google


### PR DESCRIPTION
# Why?

GKE sets CPU resource limit to 100mCPU by default. The `dashboard-service` needs more resources. I also removed resource limits for other services to use the GKE default value because we do have enough resources now.